### PR TITLE
Avoid lowercasing patterns before storage

### DIFF
--- a/Bouncer/Models/FilterStore/FilterStore.swift
+++ b/Bouncer/Models/FilterStore/FilterStore.swift
@@ -27,7 +27,7 @@ struct Filter: Identifiable, Equatable, Codable {
     init(id: UUID, phrase: String, type: FilterType = .any, action: FilterDestination = .junk) {
         self.id = id
         self.type = type
-        self.phrase = phrase.lowercased()
+        self.phrase = phrase
         self.action = action
     }
 }

--- a/Bouncer/Models/SMSFilter/SMSOfflineFilter.swift
+++ b/Bouncer/Models/SMSFilter/SMSOfflineFilter.swift
@@ -27,7 +27,7 @@ struct SMSOfflineFilter {
                 txt = "\(message.sender) \(message.text)"
         }
 
-        return txt.lowercased().contains(filter.phrase.lowercased()) || (txt.range(of: filter.phrase, options:[.regularExpression, .caseInsensitive]) != nil)
+        return txt.localizedCaseInsensitiveContains(filter.phrase) || (txt.range(of: filter.phrase, options:[.regularExpression, .caseInsensitive]) != nil)
     }
     
     func filterMessage(message: SMSMessage) -> ILMessageFilterAction {

--- a/Bouncer/Models/SMSFilter/SMSOfflineFilter.swift
+++ b/Bouncer/Models/SMSFilter/SMSOfflineFilter.swift
@@ -27,7 +27,7 @@ struct SMSOfflineFilter {
                 txt = "\(message.sender) \(message.text)"
         }
 
-        return txt.lowercased().contains(filter.phrase) || (txt.range(of: filter.phrase, options:[.regularExpression, .caseInsensitive]) != nil)
+        return txt.lowercased().contains(filter.phrase.lowercased()) || (txt.range(of: filter.phrase, options:[.regularExpression, .caseInsensitive]) != nil)
     }
     
     func filterMessage(message: SMSMessage) -> ILMessageFilterAction {


### PR DESCRIPTION
For regexes, case is important because \b and \B are exact opposites (similar with \d and \D, \w and \W, etc.)

In the future, whether a filter should be case-sensitive or treated as a string versus regex match can be handled by marking those explicitly as separate attributes.