### PR TITLE
Update launch tutorial to work on SE first gen

### DIFF
--- a/Bouncer.xcodeproj/project.pbxproj
+++ b/Bouncer.xcodeproj/project.pbxproj
@@ -772,7 +772,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.2.0;
+				MARKETING_VERSION = 2.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.banshai.bouncer.smsfilter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -794,7 +794,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.2.0;
+				MARKETING_VERSION = 2.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.banshai.bouncer.smsfilter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -941,7 +941,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.2.0;
+				MARKETING_VERSION = 2.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.banshai.bouncer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -969,7 +969,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.2.0;
+				MARKETING_VERSION = 2.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.banshai.bouncer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Bouncer/Info.plist
+++ b/Bouncer/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>167</string>
+	<string>169</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>

--- a/Bouncer/Views/Tutorial/TutorialView.swift
+++ b/Bouncer/Views/Tutorial/TutorialView.swift
@@ -24,14 +24,13 @@ struct TutorialView: View {
                         Text("WELCOME_SUBTITLE")
                             .font(.largeTitle)
                             .foregroundColor(Color("TextDefaultColor"))
-                            .padding(.bottom, 60.0)
+                            .padding(.bottom, 20.0)
                     }
                     else {
                         Text("HELP")
                             .font(.largeTitle)
                             .fontWeight(.bold)
                             .foregroundColor(Color("TextHighLightColor"))
-                            .padding(.bottom, 20.0)
                     }
                 }
                 VStack(alignment: .center) {
@@ -43,8 +42,8 @@ struct TutorialView: View {
                             .fontWeight(.bold) +
                         Text("ON_YOUR_IPHONE").foregroundColor(Color("TextDefaultColor"))
                     }
-                    .padding(.horizontal, 40.0)
-                    .padding(.top, 40)
+                    .padding(.horizontal, 20.0)
+                    .padding(.top, 20)
                     .fixedSize(horizontal: false, vertical: true)
                     .multilineTextAlignment(.center)
 
@@ -91,7 +90,7 @@ struct TutorialView: View {
                             Text( "'Bouncer'").foregroundColor(Color("TextDefaultColor"))
                         }
                     }
-                    .padding(.bottom, 35)
+                    .padding(.bottom, 20)
 
                     Button(action: {
                         if(!hasLaunchedApp) {

--- a/smsfilter/Info.plist
+++ b/smsfilter/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>167</string>
+	<string>169</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>


### PR DESCRIPTION
Fixes #18 

The main "First" is not showing up correctly on the iPhone SE first gen

<img width="506" alt="Screen Shot 2022-02-19 at 5 49 53 PM" src="https://user-images.githubusercontent.com/1156669/154810398-947ec6a6-1257-454b-81ad-8795a25f01b9.png">

